### PR TITLE
document: update document

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,7 +29,7 @@ curl -X POST \
   }'
 ```
 
-### /bulk-schedule (POST)
+### /audit-async (POST)
 
 Schedules one or more audits to run asynchronously, utilizing [Cloud Tasks](https://cloud.google.com/tasks). Each dispatched task calls `/audit` as a target to run and log the test.
 
@@ -42,7 +42,7 @@ Schedules one or more audits to run asynchronously, utilizing [Cloud Tasks](http
 
 ```
 curl -X POST \
-  http://127.0.0.1:8080/bulk-schedule \
+  http://127.0.0.1:8080/audit-async \
   -H 'content-type: application/json' \
   -d '{
   "urls": [

--- a/SETUP.md
+++ b/SETUP.md
@@ -22,6 +22,7 @@ The following ENV variables will need to be configured on cloud run:
 | ------------- | ------------- |
 | BQ_DATASET  | The name of a BigQuery dataset containing your results table |
 | BQ_TABLE  | The name of the BQ table to output results to |
+| GOOGLE_CLOUD_PROJECT  | ID of your cloud project |
 | CLOUD_TASKS_QUEUE  | Name of your cloud tasks queue |
 | CLOUD_TASKS_QUEUE_LOCATION  | Location of the cloud task queue |
 | SERVICE_URL  | base url and protocol of the deployed service on cloud run |

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,7 +10,7 @@ Tag the built image for GCR targeting the cloud project
 
 `docker tag lasso gcr.io/[CLOUD-PROJECT-ID]/lasso:[TAG]`
 
-Push to GCR (Make sure the GCR API is [enabled](https://console.cloud.google.com/apis/api/containerregistry.googleapis.com/overview?project=lasso-285806) already)
+Push to GCR (Make sure the GCR API is [enabled](https://console.cloud.google.com/apis/api/containerregistry.googleapis.com/overview) already)
 
 `docker push gcr.io/[CLOUD-PROJECT-ID]/lasso:[TAG]`
 


### PR DESCRIPTION
I have modified the documentation for API path, GCR API link and Cloud Run environment variables.

The GOOGLE_CLOUD_PROJECT environment variable used to be defined in the container, but is not anymore.
https://cloud.google.com/run/docs/reference/container-contract#env-vars